### PR TITLE
Display a popup for missing challenge error instead of the 404 page.

### DIFF
--- a/src/components/AwesomeError/AwesomeError.tsx
+++ b/src/components/AwesomeError/AwesomeError.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { createUseStyles } from 'src/lib/jss';
 import { Mutunachi } from '../Mutunachi/Mutunachi';
 import { AspectRatio, AspectRatioProps } from '../AspectRatio';
-import { colors, fonts, minMediaQuery } from 'src/theme';
-import { Dialog } from '../Dialog';
+import { colors, minMediaQuery } from 'src/theme';
 
 const errorsMap = {
   resourceNotFound: {
@@ -13,69 +12,23 @@ const errorsMap = {
   },
   genericError: {
     title: 'Ooops. Something went wrong!',
-    description: `I'm not sure what to advice. Hmm – Try Again?!`,
+    description: `I'm not sure what to advice. Hmm – Try Again?!`,
     mid: '3',
   },
-  missingChallengeError: {
-    title: `Ooops, it looks like the challenge doesn't exist anymore!`,
-    description: 'Why not create a new challenge?',
-    mid: '5',
-  },
 };
-type Props =
-  | {
-      popup?: undefined;
-    }
-  | {
-      popup: true;
-      onClear: () => void;
-    };
 
 export type AwesomeErrorProps = AspectRatioProps & {
   minimal?: boolean;
   errorType?: keyof typeof errorsMap;
-} & Props;
+};
 
 export const AwesomeError: React.FC<AwesomeErrorProps> = ({
   aspectRatio = { width: 1, height: 1 },
   minimal,
   errorType = 'genericError',
-  ...props
 }) => {
   const cls = useStyles();
-  if (props.popup) {
-    return (
-      <div className={cls.container}>
-        <Dialog
-          hasCloseButton={false}
-          visible
-          buttons={[
-            {
-              label: 'Ok',
-              type: 'primary',
-              onClick: props.onClear,
-            },
-          ]}
-          content={
-            <div>
-              <Mutunachi
-                mid={errorsMap[errorType].mid}
-                style={{ maxHeight: '200px', marginBottom: '10px' }}
-              />
-              <div style={{ textAlign: 'center' }}>
-                <div className={cls.title} style={{ marginBottom: '10px' }}>
-                  {errorsMap[errorType].title}
-                </div>
-                <div style={{ color: colors.neutralDarker, ...fonts.body2 }}>
-                  {errorsMap[errorType].description}
-                </div>
-              </div>
-            </div>
-          }
-        />
-      </div>
-    );
-  }
+
   return (
     <div className={cls.container}>
       <AspectRatio aspectRatio={aspectRatio} className={cls.mutunachiContainer}>
@@ -90,6 +43,8 @@ export const AwesomeError: React.FC<AwesomeErrorProps> = ({
     </div>
   );
 };
+
+
 
 const useStyles = createUseStyles({
   container: {
@@ -134,5 +89,5 @@ const useStyles = createUseStyles({
     fontSize: '50%',
     color: colors.neutralDarker,
     fontWeight: 400,
-  },
+  }
 });

--- a/src/components/AwesomeError/AwesomeErrorPage.tsx
+++ b/src/components/AwesomeError/AwesomeErrorPage.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 import { createUseStyles } from 'src/lib/jss';
 import { AwesomeError, AwesomeErrorProps } from './AwesomeError';
 
 type Props = {
   errorType?: AwesomeErrorProps['errorType'];
-  popup? :boolean;
 };
 
 export const AwesomeErrorPage: React.FC<Props> = (props) => {
   const cls = useStyles();
-  const history = useHistory();
   
   return (
     <div className={cls.container}>
-      <AwesomeError errorType={props.errorType} popup onClear={() => history.push('/')}/>
+      <AwesomeError errorType={props.errorType}/>
     </div>
   );
 };

--- a/src/components/AwesomeErrorWithAction/AwesomeErrorWithAction.tsx
+++ b/src/components/AwesomeErrorWithAction/AwesomeErrorWithAction.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { createUseStyles } from 'src/lib/jss';
+import { colors, fonts, minMediaQuery } from 'src/theme';
+import { ButtonProps } from '../Button';
+import { Dialog } from '../Dialog';
+import { Mutunachi } from '../Mutunachi/Mutunachi';
+
+type Props = {
+  buttons: ButtonProps[];
+  title: string;
+  desc?: string;
+  mid: string;
+};
+
+export const AwesomeErrorWithAction: React.FC<Props> = ({ buttons, title, desc, mid }) => {
+  const cls = useStyles();
+
+  return (
+    <div className={cls.container}>
+      <div className={cls.wrapper}>
+        <Dialog
+          hasCloseButton={false}
+          visible
+          buttons={buttons}
+          content={
+            <div>
+              <Mutunachi mid={mid} style={{ maxHeight: '200px', marginBottom: '10px' }} />
+              <div style={{ textAlign: 'center' }}>
+                <div className={cls.title} style={{ marginBottom: '10px' }}>
+                  {title}
+                </div>
+                <div style={{ color: colors.neutralDarker, ...fonts.body2 }}>{desc}</div>
+              </div>
+            </div>
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+const useStyles = createUseStyles({
+  container: {
+    display: 'flex',
+    height: '100vh',
+    justifyContent: 'center',
+    alignContent: 'center',
+    alignItems: 'center',
+  },
+  wrapper: {
+    width: '100%',
+    textAlign: 'center',
+    fontSize: '24px',
+
+    ...minMediaQuery(600, {
+      fontSize: '48px',
+    }),
+  },
+  textContainer: {
+    padding: '16px',
+  },
+  title: {
+    marginBottom: 0,
+    color: colors.neutralDarker,
+  },
+  description: {
+    fontSize: '50%',
+    color: colors.neutralDarker,
+    fontWeight: 400,
+  },
+});

--- a/src/modules/Challenges/ChallengeOrRoomPage.tsx
+++ b/src/modules/Challenges/ChallengeOrRoomPage.tsx
@@ -9,6 +9,7 @@ import { GenericRoomPage } from 'src/modules/Rooms/GenericRoom';
 import { useSelector } from 'react-redux';
 import { selectAuthentication } from 'src/services/Authentication';
 import { ChallengePage } from './ChallengePage';
+import { AwesomeErrorWithAction } from 'src/components/AwesomeErrorWithAction/AwesomeErrorWithAction';
 
 type Props = {};
 
@@ -69,7 +70,22 @@ export const ChallengeOrRoomPage: React.FC<Props> = () => {
   }
 
   if (resourceState === 'error') {
-    return <AwesomeErrorPage errorType='missingChallengeError' />;
+    return (
+      <AwesomeErrorWithAction
+        title={`Ooops, it looks like the challenge doesn't exist anymore!`}
+        desc="Why not create a new challenge?"
+        mid="5"
+        buttons={[
+          {
+            type: 'primary',
+            label: 'OK',
+            onClick: () => {
+              history.push('/');
+            },
+          },
+        ]}
+      />
+    );
   }
 
   // This should be something more specific!


### PR DESCRIPTION
fix [https://trello.com/c/n15LwaYe/31-when-a-challenge-is-not-available-anymore-the-error-message-should-be-more-descriptive](https://trello.com/c/n15LwaYe/31-when-a-challenge-is-not-available-anymore-the-error-message-should-be-more-descriptive)