### PR TITLE
Fix timer displaying 1:00 instead of 01:00 so all formats are 00:00

### DIFF
--- a/src/modules/Games/Chess/components/Countdown/Countdown.tsx
+++ b/src/modules/Games/Chess/components/Countdown/Countdown.tsx
@@ -78,7 +78,7 @@ export const Countdown: React.FC<Props> = ({ onFinished = () => noop, gameTimeCl
         </Text>
       ) : (
         <Text className={cx(cls.text, cls.countdownMilliseconds)}>
-          <Text className={cx(cls.text, cls.major, cls.countdownMilliseconds)}>0:</Text>
+          <Text className={cx(cls.text, cls.major, cls.countdownMilliseconds)}>00:</Text>
           <Text className={cx(cls.text, cls.minor, cls.countdownMilliseconds)}>00</Text>
         </Text>
       )}

--- a/src/modules/Games/Chess/components/Countdown/util.ts
+++ b/src/modules/Games/Chess/components/Countdown/util.ts
@@ -12,7 +12,7 @@ export const timeLeftToFormatMajor = (
   }
 
   if (timeLeftMs < hours(1)) {
-    return 'M';
+    return 'MM';
   }
   return 'H';
 };
@@ -30,7 +30,7 @@ export const timeLeftToFormatMinor = (
   if (timeLeftMs < hours(1)) {
     return 'ss';
   }
-  return 'M';
+  return 'MM';
 };
 
 export const timeLeftToInterval = (timeLeftMs: number) => {


### PR DESCRIPTION
fix [https://trello.com/c/NO90khbM/122-timer-the-last-minute-should-also-show-minsec-0000-and-shouldnt-be-in-red-for-bullet-game](https://trello.com/c/NO90khbM/122-timer-the-last-minute-should-also-show-minsec-0000-and-shouldnt-be-in-red-for-bullet-game)